### PR TITLE
add sv_tags without removing sv_tags from .cfg

### DIFF
--- a/addons/sourcemod/scripting/sm_hosties.sp
+++ b/addons/sourcemod/scripting/sm_hosties.sp
@@ -294,7 +294,17 @@ public OnConfigsExecuted()
 {
 	if (GetConVarInt(gH_Cvar_Add_ServerTag) == 1)
 	{
-		ServerCommand("sv_tags %s\n", SERVERTAG);
+		ConVar hTags = FindConVar("sv_tags");
+		char sTags[128];
+		hTags.GetString(sTags, sizeof(sTags));
+		if (StrContains(sTags, SERVERTAG, false) == -1)
+		{
+			char sTagsFormat[128];
+			Format(sTagsFormat, sizeof(sTagsFormat), ", %s", SERVERTAG);
+			
+			StrCat(sTags, sizeof(sTags), sTagsFormat);
+			hTags.SetString(sTags);
+		}
 	}
 	
 	#if (MODULE_FREEKILL == 1)


### PR DESCRIPTION
old way overwrite sv_tags setted by user in .cfg and set hosties tag instead.
new way will check for hosties tag, if not found it will be added to the sv_tags set by player. no lost of tags

all credits for this code to Headline22
https://github.com/Headline22/Hunger-Games-Beacon/